### PR TITLE
Fix explanation of negative indices

### DIFF
--- a/Tutorials/Python_Introduction.ipynb
+++ b/Tutorials/Python_Introduction.ipynb
@@ -660,7 +660,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the upper index is not inclusive (the same as in `range`). The index `-1` refers to the second last item, `-2` to the third last, and so on. Python lists are zero-indexed.\n",
+    "Note that the upper index is not inclusive (the same as in `range`). The index `-1` refers to the last item, `-2` to the second last, and so on. Python lists are zero-indexed.\n",
     "\n",
     "Unfortunately, you cannot do convenient double indexing on multidimensional lists. For this, you need numpy."
    ]


### PR DESCRIPTION
Probably meant that `l[:-1]` gives you every item up to (and including) the second last item. This agrees with the fact that the upper index is not inclusive and `-1` refers to the last item.